### PR TITLE
1、图片右上角打钩，都会出现闪烁，重新刷新问题

### DIFF
--- a/imagepicker/src/main/java/com/lzy/imagepicker/ui/ImageGridActivity.java
+++ b/imagepicker/src/main/java/com/lzy/imagepicker/ui/ImageGridActivity.java
@@ -222,7 +222,7 @@ public class ImageGridActivity extends ImageBaseActivity implements ImageDataSou
             mBtnPre.setEnabled(false);
         }
         mBtnPre.setText(getResources().getString(R.string.preview_count, imagePicker.getSelectImageCount()));
-        mImageGridAdapter.notifyDataSetChanged();
+        
     }
 
     @Override


### PR DESCRIPTION
把ImageGridActivity 里面的 mImageGridAdapter.notifyDataSetChanged();删除了，因为每次对图片进行checked 都会导致图片的刷新（闪烁）问题出现