### PR TITLE
fix CropImageView 内存泄露问题

### DIFF
--- a/imagepicker/src/main/java/com/lzy/imagepicker/ui/ImageCropActivity.java
+++ b/imagepicker/src/main/java/com/lzy/imagepicker/ui/ImageCropActivity.java
@@ -129,6 +129,7 @@ public class ImageCropActivity extends ImageBaseActivity implements View.OnClick
     @Override
     protected void onDestroy() {
         super.onDestroy();
+        mCropImageView.setOnBitmapSaveCompleteListener(null);
         if (null != mBitmap && !mBitmap.isRecycled()) {
             mBitmap.recycle();
             mBitmap = null;


### PR DESCRIPTION
裁剪图片时，  `private static CropImageView.OnBitmapSaveCompleteListener mListener;`这段代码持有了ImageCropActivity的静态引用，因此Destroy后仍然有引用存在，导致内存泄露