### PR TITLE
图片是否选中的判断逻辑修改

### DIFF
--- a/imagepicker/src/main/java/com/lzy/imagepicker/adapter/ImageRecyclerAdapter.java
+++ b/imagepicker/src/main/java/com/lzy/imagepicker/adapter/ImageRecyclerAdapter.java
@@ -162,7 +162,7 @@ public class ImageRecyclerAdapter extends RecyclerView.Adapter<ViewHolder> {
             //根据是否多选，显示或隐藏checkbox
             if (imagePicker.isMultiMode()) {
                 cbCheck.setVisibility(View.VISIBLE);
-                boolean checked = mSelectedImages.contains(imageItem);
+                boolean checked = isSelected(imageItem);
                 if (checked) {
                     mask.setVisibility(View.VISIBLE);
                     cbCheck.setChecked(true);
@@ -175,7 +175,16 @@ public class ImageRecyclerAdapter extends RecyclerView.Adapter<ViewHolder> {
             }
             imagePicker.getImageLoader().displayImage(mActivity, imageItem.path, ivThumb, mImageSize, mImageSize); //显示图片
         }
+    }
 
+    private Boolean isSelected(ImageItem imageItem) {
+        for (ImageItem item : mSelectedImages) {
+            if (item.path.equals(imageItem.path)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private class CameraViewHolder extends ViewHolder{

--- a/imagepicker/src/main/java/com/lzy/imagepicker/bean/ImageItem.java
+++ b/imagepicker/src/main/java/com/lzy/imagepicker/bean/ImageItem.java
@@ -31,4 +31,16 @@ public class ImageItem implements Serializable {
 
         return super.equals(o);
     }
+
+    public ImageItem() {}
+
+    public ImageItem(ImageItem imageItem) {
+        this.name = imageItem.name;
+        this.path = imageItem.path;
+        this.size = imageItem.size;
+        this.width = imageItem.width;
+        this.height = imageItem.height;
+        this.mimeType = imageItem.mimeType;
+        this.addTime = imageItem.addTime;
+    }
 }


### PR DESCRIPTION
1. 通过图片path来判断图片的选中；
原来是通过imageItem对的引用判断是否相等的，这样对于拍照得到的图片，无法在修改图片选择的时候显示为选中状态。改成通过图片path来判断，解决这个问题，但是比较性能上会有一定损失。

2. 为ImageItem添加一个拷贝构造方法
复杂场景下，我们可能需要继承ImageItem，此时再初始化子类的时候ImageItem需要一个拷贝构造函数。
