### PR TITLE
优化图片选择页UI， 适配预览页的横竖屏切换

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,6 +31,6 @@ dependencies {
 
     compile 'com.lzy.widget:view-core:0.2.1'
 
-    //compile 'com.lzy.widget:imagepicker:0.5.5'
+    //compile 'com.lzy.widget:imagepicker:0.6.0'
     compile project(':imagepicker')
 }

--- a/imagepicker/build.gradle
+++ b/imagepicker/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.2"
+    buildToolsVersion "25.0.3"
 
     defaultConfig {
         minSdkVersion 11

--- a/imagepicker/src/main/AndroidManifest.xml
+++ b/imagepicker/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
 
         <activity
             android:name=".ui.ImagePreviewDelActivity"
+            android:configChanges="orientation|screenSize"
             android:theme="@style/ImagePickerThemeFullScreen"/>
 
         <provider

--- a/imagepicker/src/main/java/com/lzy/imagepicker/ui/ImagePreviewActivity.java
+++ b/imagepicker/src/main/java/com/lzy/imagepicker/ui/ImagePreviewActivity.java
@@ -2,7 +2,6 @@ package com.lzy.imagepicker.ui;
 
 import android.content.Intent;
 import android.graphics.Color;
-import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.view.ViewPager;
 import android.text.format.Formatter;
@@ -16,6 +15,7 @@ import android.widget.Toast;
 import com.lzy.imagepicker.ImagePicker;
 import com.lzy.imagepicker.R;
 import com.lzy.imagepicker.bean.ImageItem;
+import com.lzy.imagepicker.util.NavigationBarChangeListener;
 import com.lzy.imagepicker.util.Utils;
 import com.lzy.imagepicker.view.SuperCheckBox;
 
@@ -37,6 +37,7 @@ public class ImagePreviewActivity extends ImagePreviewBaseActivity implements Im
     private SuperCheckBox mCbOrigin;               //原图
     private Button mBtnOk;                         //确认图片的选择
     private View bottomBar;
+    private View marginView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -44,21 +45,16 @@ public class ImagePreviewActivity extends ImagePreviewBaseActivity implements Im
 
         isOrigin = getIntent().getBooleanExtra(ImagePreviewActivity.ISORIGIN, false);
         imagePicker.addOnImageSelectedListener(this);
-
-        mBtnOk = (Button) topBar.findViewById(R.id.btn_ok);
+        mBtnOk = (Button) findViewById(R.id.btn_ok);
         mBtnOk.setVisibility(View.VISIBLE);
         mBtnOk.setOnClickListener(this);
 
         bottomBar = findViewById(R.id.bottom_bar);
         bottomBar.setVisibility(View.VISIBLE);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT && Utils.hasVirtualNavigationBar(this)) {
-            View marginView = findViewById(R.id.margin_bottom);
-            ViewGroup.LayoutParams layoutParams = marginView.getLayoutParams();
-            layoutParams.height = Utils.getNavigationBarHeight(this);
-            marginView.requestLayout();
-        }
+
         mCbCheck = (SuperCheckBox) findViewById(R.id.cb_check);
         mCbOrigin = (SuperCheckBox) findViewById(R.id.cb_origin);
+        marginView = findViewById(R.id.margin_bottom);
         mCbOrigin.setText(getString(R.string.ip_origin));
         mCbOrigin.setOnCheckedChangeListener(this);
         mCbOrigin.setChecked(isOrigin);
@@ -94,7 +90,39 @@ public class ImagePreviewActivity extends ImagePreviewBaseActivity implements Im
                 }
             }
         });
+        NavigationBarChangeListener.with(this).setListener(new NavigationBarChangeListener.OnSoftInputStateChangeListener() {
+            @Override
+            public void onNavigationBarShow(int orientation, int height) {
+                marginView.setVisibility(View.VISIBLE);
+                ViewGroup.LayoutParams layoutParams = marginView.getLayoutParams();
+                if (layoutParams.height == 0) {
+                    layoutParams.height = Utils.getNavigationBarHeight(ImagePreviewActivity.this);
+                    marginView.requestLayout();
+                }
+            }
+
+            @Override
+            public void onNavigationBarHide(int orientation) {
+                marginView.setVisibility(View.GONE);
+            }
+        });
+        NavigationBarChangeListener.with(this, NavigationBarChangeListener.ORIENTATION_HORIZONTAL)
+                .setListener(new NavigationBarChangeListener.OnSoftInputStateChangeListener() {
+                    @Override
+                    public void onNavigationBarShow(int orientation, int height) {
+                        topBar.setPadding(0, 0, height, 0);
+                        bottomBar.setPadding(0, 0, height, 0);
+                    }
+
+                    @Override
+                    public void onNavigationBarHide(int orientation) {
+                        topBar.setPadding(0, 0, 0, 0);
+                        bottomBar.setPadding(0, 0, 0, 0);
+                    }
+                });
     }
+
+
 
     /**
      * 图片添加成功后，修改当前图片的选中数量

--- a/imagepicker/src/main/java/com/lzy/imagepicker/ui/ImagePreviewDelActivity.java
+++ b/imagepicker/src/main/java/com/lzy/imagepicker/ui/ImagePreviewDelActivity.java
@@ -2,7 +2,6 @@ package com.lzy.imagepicker.ui;
 
 import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.res.Configuration;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v4.view.ViewPager;

--- a/imagepicker/src/main/java/com/lzy/imagepicker/ui/ImagePreviewDelActivity.java
+++ b/imagepicker/src/main/java/com/lzy/imagepicker/ui/ImagePreviewDelActivity.java
@@ -2,6 +2,7 @@ package com.lzy.imagepicker.ui;
 
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.os.Bundle;
 import android.support.v4.view.ViewPager;
@@ -12,6 +13,7 @@ import android.widget.ImageView;
 
 import com.lzy.imagepicker.ImagePicker;
 import com.lzy.imagepicker.R;
+import com.lzy.imagepicker.util.NavigationBarChangeListener;
 
 /**
  * ================================================
@@ -42,6 +44,18 @@ public class ImagePreviewDelActivity extends ImagePreviewBaseActivity implements
                 mTitleCount.setText(getString(R.string.ip_preview_image_count, mCurrentPosition + 1, mImageItems.size()));
             }
         });
+        NavigationBarChangeListener.with(this, NavigationBarChangeListener.ORIENTATION_HORIZONTAL)
+                .setListener(new NavigationBarChangeListener.OnSoftInputStateChangeListener() {
+                    @Override
+                    public void onNavigationBarShow(int orientation, int height) {
+                        topBar.setPadding(0, 0, height, 0);
+                    }
+
+                    @Override
+                    public void onNavigationBarHide(int orientation) {
+                        topBar.setPadding(0, 0, 0, 0);
+                    }
+                });
     }
 
     @Override

--- a/imagepicker/src/main/java/com/lzy/imagepicker/util/NavigationBarChangeListener.java
+++ b/imagepicker/src/main/java/com/lzy/imagepicker/util/NavigationBarChangeListener.java
@@ -55,7 +55,7 @@ public class NavigationBarChangeListener implements ViewTreeObserver.OnGlobalLay
                 Utils.getNavigationBarHeight(rootView.getContext()) : 0;
         if (heightDiff >= navigationBarHeight && heightDiff < navigationBarHeight * 2) {
             if (!isShowNavigationBar && listener != null) {
-                listener.onNavigationBarShow(orientation, navigationBarHeight);
+                listener.onNavigationBarShow(orientation, heightDiff);
             }
             isShowNavigationBar = true;
         } else {

--- a/imagepicker/src/main/java/com/lzy/imagepicker/util/NavigationBarChangeListener.java
+++ b/imagepicker/src/main/java/com/lzy/imagepicker/util/NavigationBarChangeListener.java
@@ -1,0 +1,97 @@
+package com.lzy.imagepicker.util;
+
+import android.app.Activity;
+import android.graphics.Rect;
+import android.view.View;
+import android.view.ViewTreeObserver;
+
+
+/**
+ * Created by z-chu on 2017/9/4
+ * 用于监听导航栏的显示和隐藏，主要用于适配华为EMUI系统上虚拟导航栏可随时收起和展开的情况
+ */
+
+public class NavigationBarChangeListener implements ViewTreeObserver.OnGlobalLayoutListener {
+
+
+    /**
+     * 监听竖屏模式导航栏的显示和隐藏
+     */
+    public static final int ORIENTATION_VERTICAL = 1;
+
+    /**
+     * 监听横屏模式导航栏的显示和隐藏
+     */
+    public static final int ORIENTATION_HORIZONTAL = 2;
+
+    private Rect rect;
+
+    private View rootView;
+
+    private boolean isShowNavigationBar = false;
+
+    private int orientation;
+
+    private OnSoftInputStateChangeListener listener;
+
+
+    public NavigationBarChangeListener(View rootView, int orientation) {
+        this.rootView = rootView;
+        this.orientation = orientation;
+        rect = new Rect();
+    }
+
+    @Override
+    public void onGlobalLayout() {
+        rect.setEmpty();
+        rootView.getWindowVisibleDisplayFrame(rect);
+        int heightDiff = 0;
+        if (orientation == ORIENTATION_VERTICAL) {
+            heightDiff = rootView.getHeight() - (rect.bottom - rect.top);
+        } else if (orientation == ORIENTATION_HORIZONTAL) {
+            heightDiff = rootView.getWidth() - (rect.right - rect.left);
+        }
+        int navigationBarHeight = Utils.hasVirtualNavigationBar(rootView.getContext()) ?
+                Utils.getNavigationBarHeight(rootView.getContext()) : 0;
+        if (heightDiff >= navigationBarHeight && heightDiff < navigationBarHeight * 2) {
+            if (!isShowNavigationBar && listener != null) {
+                listener.onNavigationBarShow(orientation, navigationBarHeight);
+            }
+            isShowNavigationBar = true;
+        } else {
+
+            if (isShowNavigationBar && listener != null) {
+                listener.onNavigationBarHide(orientation);
+            }
+            isShowNavigationBar = false;
+        }
+    }
+
+    public void setListener(OnSoftInputStateChangeListener listener) {
+        this.listener = listener;
+    }
+
+    public interface OnSoftInputStateChangeListener {
+        void onNavigationBarShow(int orientation, int height);
+
+        void onNavigationBarHide(int orientation);
+    }
+
+    public static NavigationBarChangeListener with(View rootView) {
+        return with(rootView, ORIENTATION_VERTICAL);
+    }
+
+    public static NavigationBarChangeListener with(Activity activity) {
+        return with(activity.findViewById(android.R.id.content), ORIENTATION_VERTICAL);
+    }
+
+    public static NavigationBarChangeListener with(View rootView, int orientation) {
+        NavigationBarChangeListener softInputHeightListener = new NavigationBarChangeListener(rootView, orientation);
+        rootView.getViewTreeObserver().addOnGlobalLayoutListener(softInputHeightListener);
+        return softInputHeightListener;
+    }
+
+    public static NavigationBarChangeListener with(Activity activity, int orientation) {
+        return with(activity.findViewById(android.R.id.content), orientation);
+    }
+}

--- a/imagepicker/src/main/res/drawable/ic_cover_shade.xml
+++ b/imagepicker/src/main/res/drawable/ic_cover_shade.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <gradient
+        android:angle="270"
+        android:startColor="#19000000"
+        android:endColor="#00000000"
+        />
+</shape>

--- a/imagepicker/src/main/res/layout/adapter_image_list_item.xml
+++ b/imagepicker/src/main/res/layout/adapter_image_list_item.xml
@@ -12,6 +12,11 @@
         android:src="@drawable/ic_default_image" />
 
     <View
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@drawable/ic_cover_shade" />
+
+    <View
         android:id="@+id/mask"
         android:layout_width="match_parent"
         android:layout_height="match_parent"


### PR DESCRIPTION
* 优化图片选择页UI，在图片上铺上一层阴影，防止白色图片看不到选中框
**优化前**
    ![](http://7xq7yd.com1.z0.glb.clouddn.com/Screenshot_20170904-150308.png?imageView2/0/w/540)
**优化后**
    ![](http://7xq7yd.com1.z0.glb.clouddn.com/Screenshot_20170904-150417.png?imageView2/0/w/540)
* 适配预览页的横竖屏切换、适配华为EMUI系统上虚拟导航栏可随时收起和展开的情况
  (横竖屏不好录制，这里就省略了)
  ![](http://7xq7yd.com1.z0.glb.clouddn.com/imagepicker2122ds.gif)


