### PR TITLE
去掉Bitmap的回收代码

### DIFF
--- a/imagepicker/src/main/java/com/lzy/imagepicker/util/BitmapUtil.java
+++ b/imagepicker/src/main/java/com/lzy/imagepicker/util/BitmapUtil.java
@@ -69,9 +69,9 @@ public class BitmapUtil {
         matrix.postRotate(degree);
         // 将原始图片按照旋转矩阵进行旋转，并得到新的图片
         Bitmap newBitmap = Bitmap.createBitmap(bitmap, 0, 0, bitmap.getWidth(), bitmap.getHeight(), matrix, true);
-        if (!bitmap.isRecycled()) {
-            bitmap.recycle();
-        }
+       // if (!bitmap.isRecycled()) {
+       //     bitmap.recycle();
+       // }
         return newBitmap;
     }
 


### PR DESCRIPTION
去掉Bitmap的回收代码, 因其在某些机型系统上，会引发'使用已回收的Bitmap'的异常，而导致崩溃